### PR TITLE
Bump purescript-prelude requirement to ^2.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
   ],
   "dependencies": {
     "purescript-foldable-traversable": "^2.0.0",
-    "purescript-prelude": "^2.4.0"
+    "purescript-prelude": "^2.5.0"
   }
 }


### PR DESCRIPTION
This is required for the `Eq1` and `Ord1` instances.

See https://github.com/purescript/purescript-maybe/issues/28