### PR TITLE
correct docs for Apply instance

### DIFF
--- a/src/Data/Either.purs
+++ b/src/Data/Either.purs
@@ -57,7 +57,7 @@ instance bifunctorEither :: Bifunctor Either where
 -- | `Left` values are left untouched:
 -- |
 -- | ``` purescript
--- | Left f <*> Right x == Left x
+-- | Left f <*> Right x == Left f
 -- | Right f <*> Left y == Left y
 -- | ```
 -- |


### PR DESCRIPTION
`Left` values are untouched by `<*>`, hence

```
Left f <*> Right x == Left x
```

should be

```
Left f <*> Right x == Left f
```