### PR TITLE
Derive Generic instance for Either

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "purescript-bifunctors": "master",
     "purescript-control": "master",
     "purescript-foldable-traversable": "master",
+    "purescript-generics-rep": "master",
     "purescript-invariant": "master",
     "purescript-maybe": "master",
     "purescript-prelude": "master"

--- a/src/Data/Either.purs
+++ b/src/Data/Either.purs
@@ -12,6 +12,7 @@ import Data.Foldable (class Foldable)
 import Data.FoldableWithIndex (class FoldableWithIndex)
 import Data.Functor.Invariant (class Invariant, imapF)
 import Data.FunctorWithIndex (class FunctorWithIndex)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..), maybe, maybe')
 import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
@@ -39,6 +40,8 @@ derive instance functorEither :: Functor (Either a)
 
 instance functorWithIndexEither :: FunctorWithIndex Unit (Either a) where
   mapWithIndex f = map $ f unit
+
+derive instance genericEither :: Generic (Either a b) _
 
 instance invariantEither :: Invariant (Either a) where
   imap = imapF


### PR DESCRIPTION
https://github.com/purescript/purescript-generics-rep/pull/34#issuecomment-490680971 says:

> The instance for Either should live in `purescript-either` instead, and should be derivable.

I'm not sure if the concerns expressed in that other PR apply here.