### PR TITLE
Add `blush` as the opposite of `hush`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `blush` which is a left-biased `hush`, thus turns `Right`s into `Nothing`s but `Left`s into `Just`s (#69).
 
 Bugfixes:
 
@@ -148,6 +149,3 @@ Add `Alt` instance
 
 
 ## [v0.1.0](https://github.com/purescript/purescript-either/releases/tag/v0.1.0) - 2014-04-21
-
-
-

--- a/src/Data/Either.purs
+++ b/src/Data/Either.purs
@@ -273,7 +273,7 @@ note a = maybe (Left a) Right
 note' :: forall a b. (Unit -> a) -> Maybe b -> Either a b
 note' f = maybe' (Left <<< f) Right
 
--- | Turns an `Either` into a `Maybe`, by throwing eventual `Left` values away and converting
+-- | Turns an `Either` into a `Maybe`, by throwing potential `Left` values away and converting
 -- | them into `Nothing`. `Right` values get turned into `Just`s.
 -- |
 -- | ```purescript
@@ -282,3 +282,13 @@ note' f = maybe' (Left <<< f) Right
 -- | ```
 hush :: forall a b. Either a b -> Maybe b
 hush = either (const Nothing) Just
+
+-- | Turns an `Either` into a `Maybe`, by throwing potential `Right` values away and converting
+-- | them into `Nothing`. `Left` values get turned into `Just`s.
+-- |
+-- | ```purescript
+-- | blush (Left "ParseError") = Just "Parse Error"
+-- | blush (Right 42) = Nothing
+-- | ```
+blush :: forall a b. Either a b -> Maybe a
+blush = either Just (const Nothing)


### PR DESCRIPTION
**Description of the change**

Adds a method `blush` that turns `Either`s into `Maybe`s of their possible `Left` values. 
Often, I only care about Errors (e.g. when I have an `Either Err Unit`) and this function would come in handy. 
Feel free to close this if you think it's a bad idea.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
