### PR TITLE
Add `lefts` and `rights` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `lefts` and `rights` functions (#71 by @l-monnier)
 
 Bugfixes:
 

--- a/src/Data/Either.purs
+++ b/src/Data/Either.purs
@@ -2,6 +2,7 @@ module Data.Either where
 
 import Prelude
 
+import Control.Bind (bindFlipped)
 import Control.Alt (class Alt, (<|>))
 import Control.Extend (class Extend)
 import Data.Eq (class Eq1)
@@ -252,6 +253,38 @@ fromRight default _ = default
 fromRight' :: forall a b. (Unit -> b) -> Either a b -> b
 fromRight' _ (Right b) = b
 fromRight' default _ = default unit
+
+-- | Keep from a `Monad` (typically an `Array`) of `Either` all
+-- | the `Left` elements.
+-- |
+-- | For `Monad` with an order (such as `Array`),
+-- | the initial order of the `Left` elements is preserved.
+-- | 
+-- | A possible use case is to collect all errors of multiple `Either`.
+-- |
+-- | The type signature being more general than `Array`, it is possible to
+-- | use it with other types such as `List`.
+-- |
+-- | ```purescript
+-- | lefts [Left "Error 1", Right 42, Left "Error 2"] = ["Error 1", "Error 2"]
+-- | ```
+lefts :: forall a b m. Monad m => Monoid (m a) => m (Either a b) -> m a
+lefts = bindFlipped $ either pure (const mempty)
+
+-- | Keep from a `Monad` (typically an `Array`) of `Either` all
+-- | the `Right` elements.
+-- |
+-- | For `Monad` with an order (such as `Array`),
+-- | the initial order of the `Right` elements is preserved.
+-- | 
+-- | The type signature being more general than `Array`, it is possible to
+-- | use it with other types such as `List`.
+-- |
+-- | ```purescript
+-- | rights [Left "Error 1", Right 42, Left "Error 2"] = [42]
+-- | ```
+rights :: forall a b m. Monad m => Monoid (m b) => m (Either a b) -> m b
+rights = bindFlipped $ either (const mempty) pure
 
 -- | Takes a default and a `Maybe` value, if the value is a `Just`, turn it into
 -- | a `Right`, if the value is a `Nothing` use the provided default as a `Left`

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,6 +2,7 @@ module Test.Main where
 
 import Prelude
 
+import Data.Either (Either(..), lefts, rights)
 import Data.Either.Inject (inj, prj)
 import Data.Either.Nested (Either3, in1, in2, in3)
 import Data.Maybe (Maybe(..))
@@ -63,4 +64,30 @@ main = do
   assertEqual
     { actual: prj (in3 100 :: MySum)
     , expected: Nothing :: Maybe Boolean
+    }
+  log "Test lefts"
+  assertEqual
+    { actual: lefts [Left 1, Right 2, Left 3, Right 4]
+    , expected: [1, 3]
+    }
+  assertEqual
+    { actual: lefts [Right 2, Right 4]
+    , expected: [] :: Array Int
+    }
+  assertEqual
+    { actual: lefts []
+    , expected: [] :: Array Int
+    }
+  log "Test rights"
+  assertEqual
+    { actual: rights [Left 1, Right 2, Left 3, Right 4]
+    , expected: [2, 4]
+    }
+  assertEqual
+    { actual: rights [Left 1, Left 3]
+    , expected: [] :: Array Int
+    }
+  assertEqual
+    { actual: rights []
+    , expected: [] :: Array Int
     }


### PR DESCRIPTION
## Description of the change

Add a `lefts` function similar to [the one existing in Haskell Data.Either](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-Either.html#v:lefts).
Add also its "partner" `rights` function.

### Motivation

I find `lefts` useful to collect the error messages of multiple validations of a same value, when such validations do not alter the value. For example, if I want to test that a value is no longer than n, has no forbidden character, contains at least 1 number, etc. 

### Notes

As in PureScript there are `Array` and `List`, I've made the type signature more general than the Haskell one (which is only for native Haskell lists).
I've used `Monad` (and `Monoid`) to avoid introducing new dependencies. However, it seems to me that `Foldable` would be a better fit than `Monad` conceptually. But I don't think it matters much in practice.
 
The above makes the documentation a bit tricky as those functions are pretty abstract. I hope it's still understandable while remaining accurate enough. 


I let you decide if you want to include those 2 functions in the library.

## Checklist

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close [none]
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)